### PR TITLE
Catch improperly defined sqlhosts path early

### DIFF
--- a/django_informixdb/base.py
+++ b/django_informixdb/base.py
@@ -187,6 +187,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if 'DRIVER' not in options or options['DRIVER'] is None:
             options['DRIVER'] = self.get_driver_path()
         if platform.system().upper() != 'WINDOWS':
+            sqlhosts = os.environ.get('INFORMIXSQLHOSTS')
+            if not sqlhosts or not os.path.exists(sqlhosts):
+                raise ImproperlyConfigured('Cannot find Informix sqlhosts at {}'.format(sqlhosts))
             if not os.path.exists(options['DRIVER']):
                 raise ImproperlyConfigured('cannot find Informix driver at {}'.format(options['DRIVER']))
         conn_params['OPTIONS'] = options

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ basepython = python3.6
 commands = python test/manage.py test datatypes
 passenv = INFORMIXDIR
 setenv =
-    INFORMIXSQLHOSTS={env:INFORMIXDIR:None}/etc/sqlhosts
-    LD_LIBRARY_PATH={env:INFORMIXDIR:None}/lib/esql
+    INFORMIXSQLHOSTS={env:INFORMIXDIR:}/etc/sqlhosts
+    LD_LIBRARY_PATH={env:INFORMIXDIR:}/lib/esql
 
 [testenv:dj1]
 deps = Django~=1.11.2


### PR DESCRIPTION
This avoids the user getting the bizarre Informix error:

   '[HY000] [Informix][Informix ODBC Driver][Informix]Unspecified System Error =  -23101. (-23101) (SQLDriverConnect)'