### PR TITLE
Readme update: DB_LOCALE env & its explanation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,9 @@ LD_LIBRARY_PATH
     The path(s) to the various Informix library files: Usually
     ``$INFORIMIXDIR/lib:$INFORMIXDIR/lib/cli:$IMFORMIXDIR/lib/esql``
 
+DB_LOCALE
+    In case of ``Database locale information mismatch.`` error during connection,
+    you should specify your database locale, e.g. ``DB_LOCALE=en_US.8859-15``
 
 You will also need to add an entry within your ``sqlhosts`` file for each remote/local Informix
 server connection in the following format::


### PR DESCRIPTION
Hi @richard-reece . I'm trying to use your lib, and have been stumbled with `Database locale information mismatch` error.
Hope this feedback will help some people, who are not used to Informix client env settings.

P.S.: another way I found is that one can pass the DB_LOCALE in **pyodbc** connection string:
```python
connection = pyodbc.connect("Driver={/opt/IBM/informix/lib/cli/iclit09b.so};Db_locale=de_DE.8859-15;Server=my_srv;Database=mydb;Uid=user;Pwd=pass;")
```
Do you think the right way to fix the issue will be to set LOCALE  in django database settings for each DB separately and then pass it to `pyodbc.connect()`?
