### PR TITLE
pyodbc>=4.0.21 required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     keywords='django informix',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['django>=1.9.6', 'pyodbc==4.0.21'],
+    install_requires=['django>=1.9.6', 'pyodbc>=4.0.21'],
     extras_require={
         'dev': ['check-manifest'],
         'test': ['coverage'],


### PR DESCRIPTION
Tried installing this on a python-3.7 venv and it installs fine with the latest pyodbc: 

`django-informixdb 1.4.0 has requirement pyodbc==4.0.21, but you'll have pyodbc 4.0.25 which is incompatible.`
