### PR TITLE
Encapsulate testing in a Dockerfile, and extend docker-compose to facilitate testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,81 @@
+.tox
+.cache
+.git
+*.swp
+Dockerfile*
+docker-compose.*
+test*.sh
+
+# for pycharm
+.idea/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Ipython Notebook
+.ipynb_checkpoints
+.python-version
+
+# Sublime Text
+*sublime-*
+
+# Environment
+.envrc

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,172 @@
+# vim: set ft=dockerfile:
+
+##------------------------------------------------------------------------------
+FROM python:3.6 AS py36
+
+RUN echo "${PYTHON_VERSION}" > /tmp/py36-latest
+
+##------------------------------------------------------------------------------
+FROM python:3.7 AS py37
+
+RUN echo "${PYTHON_VERSION}" > /tmp/py37-latest
+
+##------------------------------------------------------------------------------
+FROM python:3.8 AS py38
+
+RUN echo "${PYTHON_VERSION}" > /tmp/py38-latest
+
+##------------------------------------------------------------------------------
+FROM centos:7 AS base
+
+RUN yum clean all \
+ && yum update -y \
+ && yum install -y \
+        unixODBC \
+ && yum clean all \
+ && rm -rf /var/yum/cache
+
+##------------------------------------------------------------------------------
+FROM base AS builder-base
+
+RUN yum install -y \
+        make \
+        yum-utils
+
+RUN yum-builddep -y python3
+
+# For pyodbc
+RUN yum install -y \
+        unixODBC-devel
+
+RUN mkdir /src
+
+##------------------------------------------------------------------------------
+FROM builder-base AS builder-py36
+
+RUN mkdir /opt/py36 && chown -R 3036 /opt/py36 /src
+USER 3036
+WORKDIR /tmp
+
+COPY --from=py36 /tmp/py36-latest /tmp/
+
+RUN export PYTHON_VERSION="$(cat /tmp/py36-latest)" \
+ && curl --silent --show-error --fail --location \
+        "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" \
+    | tar -xz
+
+RUN export PYTHON_VERSION="$(cat /tmp/py36-latest)" \
+ && cd "/tmp/Python-${PYTHON_VERSION}" \
+ && ./configure --prefix=/opt/py36 \
+ && make install
+
+USER root
+ENV PATH=/opt/py36/bin:"${PATH}"
+RUN pip3 install tox
+USER 3036
+
+ENV HOME=/src
+ENV PATH=/opt/py36/bin:"${PATH}"
+WORKDIR /src
+
+ADD django_informixdb/ /src/django_informixdb/
+ADD README.rst setup.* tox.ini /src/
+RUN tox -e "$(tox --listenvs | grep py36 | tr '\n' ',')" --notest  # prep venvs
+
+##------------------------------------------------------------------------------
+FROM builder-base AS builder-py37
+
+RUN mkdir /opt/py37 && chown -R 3037 /opt/py37 /src
+USER 3037
+WORKDIR /tmp
+
+COPY --from=py37 /tmp/py37-latest /tmp/
+
+RUN export PYTHON_VERSION="$(cat /tmp/py37-latest)" \
+ && curl --silent --show-error --fail --location \
+        "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" \
+    | tar -xz
+
+RUN export PYTHON_VERSION="$(cat /tmp/py37-latest)" \
+ && cd "/tmp/Python-${PYTHON_VERSION}" \
+ && ./configure --prefix=/opt/py37 \
+ && make install
+
+USER root
+ENV PATH=/opt/py37/bin:"${PATH}"
+RUN pip3 install tox
+USER 3037
+
+ENV HOME=/src
+ENV PATH=/opt/py37/bin:"${PATH}"
+WORKDIR /src
+
+ADD django_informixdb/ /src/django_informixdb/
+ADD README.rst setup.* tox.ini /src/
+RUN tox -e "$(tox --listenvs | grep py37 | tr '\n' ',')" --notest  # prep venvs
+
+##------------------------------------------------------------------------------
+FROM builder-base AS builder-py38
+
+RUN mkdir /opt/py38 && chown -R 3038 /opt/py38 /src
+USER 3038
+WORKDIR /tmp
+
+COPY --from=py38 /tmp/py38-latest /tmp/
+
+RUN export PYTHON_VERSION="$(cat /tmp/py38-latest)" \
+ && curl --silent --show-error --fail --location \
+        "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" \
+    | tar -xz
+
+RUN export PYTHON_VERSION="$(cat /tmp/py38-latest)" \
+ && cd "/tmp/Python-${PYTHON_VERSION}" \
+ && ./configure --prefix=/opt/py38 \
+ && make install
+
+USER root
+ENV PATH=/opt/py38/bin:"${PATH}"
+RUN pip3 install tox
+USER 3038
+
+ENV HOME=/src
+ENV PATH=/opt/py38/bin:"${PATH}"
+WORKDIR /src
+
+ADD django_informixdb/ /src/django_informixdb/
+ADD README.rst setup.* tox.ini /src/
+RUN tox -e "$(tox --listenvs | grep py38 | tr '\n' ',')" --notest  # prep venvs
+
+##------------------------------------------------------------------------------
+FROM base AS multipy
+
+COPY --from=builder-py36 /opt/py36/ /opt/py36/
+COPY --from=builder-py37 /opt/py37/ /opt/py37/
+
+COPY --from=builder-py36 /src/.tox/ /src/.tox/
+COPY --from=builder-py36 /src/.cache/ /src/.cache/
+
+COPY --from=builder-py37 /src/.tox/ /src/.tox/
+COPY --from=builder-py37 /src/.cache/ /src/.cache/
+
+ENV PATH=/opt/py38/bin:/opt/py37/bin:/opt/py36/bin:"${PATH}"
+RUN pip3 --no-cache-dir install tox
+
+##------------------------------------------------------------------------------
+FROM base AS csdk
+
+COPY --from=ibmcom/informix-developer-sandbox@sha256:678250715879a7cbdd2ea658ff7ecd7087dcaf0b8e39d47c936916edff62c5ec \
+        /home/informix/odbc/ /opt/IBM/informix/
+RUN chown -R 3793 /opt/IBM
+
+##------------------------------------------------------------------------------
+FROM multipy AS test-runner
+
+COPY --from=csdk /opt/IBM/ /opt/IBM/
+
+# make more specific ?
+ADD . /src/
+RUN chown -R 3793 /src
+
+USER 3793
+ENV HOME=/src
+WORKDIR /src

--- a/README.rst
+++ b/README.rst
@@ -293,6 +293,17 @@ Then run the test suite with:
 This will run the tests under Django 1 and 2.
 
 
+Docker based testing
+^^^^^^^^^^^^^^^^^^^^
+
+If you don't want to install the Informix libraries and multiple versions of Python locally, then you can test within
+Docker containers.
+
+Try using the helper script `test-in-docker.sh`, or inspect the script and adapt for your own purposes.
+
+Requirements: Docker 19.03.2 or newer and Docker Compose 1.24.1 or newer.
+
+
 Release History
 ---------------
 

--- a/docker-compose.sqlhosts
+++ b/docker-compose.sqlhosts
@@ -1,0 +1,1 @@
+informix        onsoctcp        informix        sqlexec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,28 @@
-version: '3'
+---
+version: '3.6'
 
 services:
+    test-runner:
+        image: ${test_runner_tag:-djifx:test-runner}
+        build:
+            context: .
+            dockerfile: Dockerfile.testing
+        environment:
+            INFORMIXDIR: /opt/IBM/informix
+            INFORMIXSQLHOSTS: /opt/IBM/informix/etc/sqlhosts
+            LD_LIBRARY_PATH: /opt/IBM/informix/lib:/opt/IBM/informix/lib/cli:/opt/IBM/informix/lib/esql
+        volumes:
+            - type: bind
+              source: ./docker-compose.sqlhosts
+              target: /opt/IBM/informix/etc/sqlhosts
+        depends_on:
+            - db
+        links:
+            - db:informix
     db:
-        image: ibmcom/informix-developer-database:12.10.FC12W1DE
-        tty: true # Needed to ensure container doesn't self terminate
+        image: ibmcom/informix-developer-database:${ifx_version:-14.10.FC3DE}
+        tty: true  # Needed to ensure container doesn't self terminate
+        hostname: db
         environment:
             LICENSE: accept
             DB_USER: adapter
@@ -16,3 +35,5 @@ services:
             - "27017:27017"
             - "27018:27018"
             - "27883:27883"
+
+# vim: set sw=4:

--- a/test-in-docker.sh
+++ b/test-in-docker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+
+docker-compose -p ifx build
+
+docker-compose -p ifx run test-runner tox

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
 
     dj1: django~=1.9.6
     dj2: django~=2.2
+    dj{1,2}: pyodbc>=4.0.21
 commands = pytest {posargs}
 passenv = INFORMIXDIR
 setenv =


### PR DESCRIPTION
This makes it so end users don't have to install the CSDK locally to perform testing.

We might be able to introduce TravisCI testing off the back of this.