### PR TITLE
bugfix/feat - Cast COUNT() to INT, fixes #22

### DIFF
--- a/django_informixdb/compiler.py
+++ b/django_informixdb/compiler.py
@@ -21,6 +21,12 @@ class SQLCompiler(compiler.SQLCompiler):
         return node, sql, params
 
     def as_sql(self, with_limits=True, with_col_aliases=False):
+        # fix informix count function and Case When
+        select = self.query.annotation_select
+        for agg in select.values():
+            if getattr(agg, 'function', '') == 'COUNT':
+                agg.template = '%s::int' % agg.template
+                
         raw_sql, fields = super(SQLCompiler, self).as_sql(False, with_col_aliases)
 
         # special dialect to return first n rows

--- a/django_informixdb/compiler.py
+++ b/django_informixdb/compiler.py
@@ -21,7 +21,7 @@ class SQLCompiler(compiler.SQLCompiler):
         return node, sql, params
 
     def as_sql(self, with_limits=True, with_col_aliases=False):
-        # fix informix count function and Case When
+        # Cast Informix COUNT() to int
         select = self.query.annotation_select
         for agg in select.values():
             if getattr(agg, 'function', '') == 'COUNT':

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -13,3 +13,7 @@ class CompilerCase(TestCase):
     def test_exists_returns_False_if_not_exists(self):
         exists = Donut.objects.filter(name="test").exists()
         self.assertFalse(exists)
+
+    def test_int_count(self):
+        count = Donut.objects.count()
+        self.assertIsInstance(count, int)


### PR DESCRIPTION
Hi I added code that will cast all `COUNT()` calls to int. 
Decimal count may not break plain Django but it's something very non-standard and can break many things. For example it makes parts of Django Rest Framework unusable since many build in mixins expect count to be int.
Fixes #22 