### PR TITLE
Drop support for Python 3.7 and 3.8; Switch to supported `docker compose` for testing

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -4,16 +4,6 @@
 ARG nonroot_uid=3973
 
 ##------------------------------------------------------------------------------
-FROM python:3.7 AS py37
-
-RUN echo "${PYTHON_VERSION}" > /tmp/py37-latest
-
-##------------------------------------------------------------------------------
-FROM python:3.8 AS py38
-
-RUN echo "${PYTHON_VERSION}" > /tmp/py38-latest
-
-##------------------------------------------------------------------------------
 FROM python:3.9 AS py39
 
 RUN echo "${PYTHON_VERSION}" > /tmp/py39-latest
@@ -61,72 +51,6 @@ RUN mkdir /usr/local/openssl11 \
  && ln -s /usr/include/openssl11 include
 
 RUN mkdir /src
-
-##------------------------------------------------------------------------------
-FROM builder-base AS builder-py37
-ARG py_ver=37
-ARG nonroot_uid
-COPY --from=py37 /tmp/py${py_ver}-latest /tmp/
-
-RUN mkdir /opt/py${py_ver} && chown -R ${nonroot_uid} /opt/py${py_ver} /src
-USER ${nonroot_uid}
-WORKDIR /tmp
-
-RUN export PYTHON_VERSION="$(cat /tmp/py${py_ver}-latest)" \
- && curl --silent --show-error --fail --location \
-        "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" \
-    | tar -xz
-
-RUN export PYTHON_VERSION="$(cat /tmp/py${py_ver}-latest)" \
- && cd "/tmp/Python-${PYTHON_VERSION}" \
- && ./configure --prefix=/opt/py${py_ver}  --enable-optimizations \
- && make -j 4 altinstall
-
-USER root
-ENV PATH=/opt/py${py_ver}/bin:"${PATH}"
-RUN pip3 install tox
-USER ${nonroot_uid}
-
-ENV HOME=/src
-ENV PATH=/opt/py${py_ver}/bin:"${PATH}"
-WORKDIR /src
-
-ADD django_informixdb/ /src/django_informixdb/
-ADD README.rst setup.* tox.ini /src/
-RUN tox -e "$(tox --listenvs | grep py${py_ver} | tr '\n' ',')" --notest  # prep venvs
-
-##------------------------------------------------------------------------------
-FROM builder-base AS builder-py38
-ARG py_ver=38
-ARG nonroot_uid
-COPY --from=py38 /tmp/py${py_ver}-latest /tmp/
-
-RUN mkdir /opt/py${py_ver} && chown -R ${nonroot_uid} /opt/py${py_ver} /src
-USER ${nonroot_uid}
-WORKDIR /tmp
-
-RUN export PYTHON_VERSION="$(cat /tmp/py${py_ver}-latest)" \
- && curl --silent --show-error --fail --location \
-        "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" \
-    | tar -xz
-
-RUN export PYTHON_VERSION="$(cat /tmp/py${py_ver}-latest)" \
- && cd "/tmp/Python-${PYTHON_VERSION}" \
- && ./configure --prefix=/opt/py${py_ver}  --enable-optimizations \
- && make -j 4 altinstall
-
-USER root
-ENV PATH=/opt/py${py_ver}/bin:"${PATH}"
-RUN pip3 install tox
-USER ${nonroot_uid}
-
-ENV HOME=/src
-ENV PATH=/opt/py${py_ver}/bin:"${PATH}"
-WORKDIR /src
-
-ADD django_informixdb/ /src/django_informixdb/
-ADD README.rst setup.* tox.ini /src/
-RUN tox -e "$(tox --listenvs | grep py${py_ver} | tr '\n' ',')" --notest  # prep venvs
 
 ##------------------------------------------------------------------------------
 FROM builder-base AS builder-py39
@@ -206,14 +130,6 @@ COPY --chown=${nonroot_uid} \
 FROM csdk AS multipy
 ARG nonroot_uid
 
-COPY --from=builder-py37 /opt/py37/ /opt/py37/
-COPY --from=builder-py37 /src/.tox/ /src/.tox/
-COPY --from=builder-py37 /src/.cache/ /src/.cache/
-
-COPY --from=builder-py38 /opt/py38/ /opt/py38/
-COPY --from=builder-py38 /src/.tox/ /src/.tox/
-COPY --from=builder-py38 /src/.cache/ /src/.cache/
-
 COPY --from=builder-py39 /opt/py39/ /opt/py39/
 COPY --from=builder-py39 /src/.tox/ /src/.tox/
 COPY --from=builder-py39 /src/.cache/ /src/.cache/
@@ -230,7 +146,7 @@ ADD --chown=${nonroot_uid} django_informixdb/ /src/django_informixdb/
 ADD --chown=${nonroot_uid} test/ /src/test/
 RUN chown ${nonroot_uid} /src
 
-ENV PATH=/opt/py310/bin:/opt/py39/bin:/opt/py38/bin:/opt/py37/bin:"${PATH}"
+ENV PATH=/opt/py310/bin:/opt/py39/bin:"${PATH}"
 RUN pip3 --no-cache-dir install tox
 
 USER ${nonroot_uid}

--- a/README.rst
+++ b/README.rst
@@ -307,6 +307,12 @@ Requirements: Docker 19.03.2 or newer and Docker Compose 1.24.1 or newer.
 Release History
 ---------------
 
+Version 1.12.1
+
+- End support for Python 3.7
+- End support for Python 3.8
+- Rework to newer Docker Compose for testing
+
 Version 1.11.4
 
 - Update pyproject.toml / setup.cfg and update docker tests to use Rocky9 instead of Centos7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ classifiers=[
     'Topic :: Scientific/Engineering',
     'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
 ]

--- a/test-in-docker.sh
+++ b/test-in-docker.sh
@@ -8,18 +8,18 @@ export uniq_test_id="${uniq_test_id:-djifx}"
 
 cleanup() {
     echo "--- cleaning up: previous code ${?}"
-    docker-compose -p "${uniq_test_id}" down --volumes --remove-orphans
+    docker compose -p "${uniq_test_id}" down --volumes --remove-orphans
 }
 trap cleanup EXIT
 
 echo "--- building docker images"
-docker-compose -p "${uniq_test_id}" build
+docker compose -p "${uniq_test_id}" build
 
 echo "--- starting dependencies"
-docker-compose -p "${uniq_test_id}" up -d db
+docker compose -p "${uniq_test_id}" up -d db
 
 echo "--- waiting for dependencies"
-docker-compose -p "${uniq_test_id}" run test-runner /usr/local/bin/wait-for-deps.sh
+docker compose -p "${uniq_test_id}" run test-runner /usr/local/bin/wait-for-deps.sh
 
 echo "--- running tests"
-docker-compose -p "${uniq_test_id}" run test-runner tox
+docker compose -p "${uniq_test_id}" run test-runner tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37-dj3,py38-dj3,py39-dj3,py310-dj3,py38-dj4,py39-dj4,py310-dj4
+envlist = py39-dj3,py310-dj3,py39-dj4,py310-dj4
 
 [testenv]
 deps =


### PR DESCRIPTION
Py3.7 and Py3.8 are end-of-life

Docker Compose v1 is also deprecated