### PR TITLE
Fixup GHA token permission for releasing

### DIFF
--- a/.github/workflows/test-build-release.yaml
+++ b/.github/workflows/test-build-release.yaml
@@ -64,6 +64,9 @@ jobs:
       - test
       - build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Hoping to fix this error:

```
  Attempting to create or update release tag "1.13.0"
  Could not create new tag "refs/tags/1.13.0" (Resource not accessible by integration) therefore updating existing tag "tags/1.13.0"
  Error: Resource not accessible by integration
```